### PR TITLE
Update base.config

### DIFF
--- a/conf/base.config
+++ b/conf/base.config
@@ -9,9 +9,9 @@ process {
     time = { 2.h * task.attempt }
   }
   withLabel: setting_2 {
-    cpus = 4
-    memory = { 96.GB * task.attempt }
-    time = { 6.h * task.attempt }
+    cpus = 16
+    memory = { 128.GB * task.attempt }
+    time = { 24.h * task.attempt }
   }
   withLabel: setting_3 {
     cpus = 4


### PR DESCRIPTION
With the current seeting_2 the BLASTN_NT_CAP3 process timeouts due to inadequate resources.  


Proposed setting_2
cpus -16
memory - 128GB
time-24hrs